### PR TITLE
Converted to use non experimental API

### DIFF
--- a/eventPage.js
+++ b/eventPage.js
@@ -6,12 +6,10 @@ initStorage();
 
 // init storage engine on load
 function initStorage() {
-	storage.get('enabled', function(result){ 
-		console.log(result);
-		if(typeof result['enabled'] === 'undefined') {
+	storage.get('enabled', function(result){
+		//console.log(result['enabled']);
+		if(result['enabled'] === undefined) {
 			enabled = true;
-			var not = webkitNotifications.createNotification('caffeineEnabled.png', 'Caffeine Enabled!', 'Your Chromebook now has a good supply of Caffeine and will stay awake forever! (meaning that automatic power management has been disabled) You can always take away the Caffeine (in effect turn back on the automatic power management) by clicking / toggling the Caffeine extension icon.');
-			not.show();
 		} else {
 			enabled = result['enabled'];
 		}
@@ -26,27 +24,39 @@ function initStorage() {
 function saveStorage() {
 	storage.set({'enabled':enabled}, function() { console.log('saved in chrome.storage.local: '+enabled); });
 }
+//shows a notification telling the user that Caffeine has been enabled
+function showNotification() {
+   chrome.notifications.create("welcome", {
+      type: "basic",
+      iconUrl: "caffeineEnabled.png",
+      title: "Caffeine Enabled!",
+      message: "Your Chromebook now has a good supply of Caffeine and will stay awake forever! (meaning that automatic power management has been disabled) You can always take away the Caffeine (in effect turn back on the automatic power management) by clicking / toggling the Caffeine extension icon."
+	}, function (notificationId) {
+	   //callback needs to be included for notifications to work!
+	});
+}
 // toggles the power management to off
 function caffeineEnable() {
-	chrome.experimental.power.requestKeepAwake( function(result) {});
+	chrome.power.requestKeepAwake("display");
 	chrome.browserAction.setIcon({path: '/caffeineEnabled.png'});
 	//chrome.browserAction.setBadgeText({ text: "c" });
-	console.log('requestKeepAwake: '+enabled);
+	//console.log('requestKeepAwake: '+enabled);
 	saveStorage();
+   showNotification();
 }
 // re-engages the system power management
 function caffeineDisable() {
-	chrome.experimental.power.releaseKeepAwake( function(result) {});
+	chrome.power.releaseKeepAwake();
 	chrome.browserAction.setIcon({path: '/caffeineDisabled.png'});
 	//chrome.browserAction.setBadgeText({ text: '0'});
-	console.log('releaseKeepAwake: '+enabled);
+	//console.log('releaseKeepAwake: '+enabled);
 	saveStorage();
 }
 //listens for events when storage changes (debug)
 chrome.storage.onChanged.addListener(function(changes, namespace) {
     for (key in changes) {
         var storageChange = changes[key];
-        console.log('Storage key "%s" in namespace "%s" changed. Old value was: %s, new value is: %s', key, namespace, storageChange.oldValue, storageChange.newValue);
+        //console.log('Storage key "%s" in namespace "%s" changed. Old value was: %s, new value is: %s', key, namespace, storageChange.oldValue, storageChange.newValue);
     }
 });
 // listens for events when the button is toggled

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Caffeine",
-	"version": "2",
+	"version": "2.1",
 	"manifest_version": 2,
 		
     "description": "Gives your ChromeBook the juice to stay awake!",
@@ -18,7 +18,7 @@
 	
 	"offline_enabled": true,
 	
-	"permissions": ["experimental", "storage", "notifications"],
+	"permissions": ["power", "storage", "notifications"],
 	
     "web_accessible_resources": ["caffeineEnabled.png"]
 }


### PR DESCRIPTION
Power management is no longer in the experimental namespace. I have modified the extension to use the new power API and notification API to correctly display a notification when then extension is activated by the user.